### PR TITLE
Fix CORS for `/health`

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -68,13 +68,16 @@ class DiscoveryPublisher {
 		}
 	}
 
-	async refreshDiscovery() {
-		return await anonDiscoveryPath(this.name).set({
+	async refreshDiscovery(): Promise<FirebaseFirestore.WriteResult> {
+		console.log("DiscoveryPublisher: refreshing discovery entry");
+		const result = await anonDiscoveryPath(this.name).set({
 			type: "api",
 			expires: new Date(Date.now() + this.expiresMillis),
 			version: "?v2",
 			domain: this.getDomain(),
 		} satisfies AnonDiscovery);
+		console.log("DiscoveryPublisher: successfully refreshed");
+		return result;
 	}
 }
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -24,7 +24,9 @@ export class CORSHandler {
 
 	handle(trace: handler.ReqContext): boolean {
 		const origin = trace.incoming.headers.origin || "";
-		if (this.allowedCorsOrigins.has(origin)) {
+		const originIsAllowed = this.allowedCorsOrigins.has(origin);
+		const thisEndpointAllowsAnyOrigin = ANY_ORIGIN_ALLOWED.has(trace.incoming.url || "");
+		if (originIsAllowed || thisEndpointAllowsAnyOrigin) {
 			const response = trace.response;
 			response.setHeader("access-control-allow-origin", origin);
 			response.setHeader("access-control-allow-methods", "POST, GET, OPTIONS, DELETE");
@@ -70,7 +72,7 @@ export class Server {
 	) {
 		const trace = new handler.ReqContext(incoming, response);
 
-		if (!ANY_ORIGIN_ALLOWED.has(trace.incoming.url || "") && this.corsHandler.handle(trace)) {
+		if (this.corsHandler.handle(trace)) {
 			return;
 		}
 


### PR DESCRIPTION
A previous refactor accidentally stripped the CORS headers from the `/health` endpoint (only).

This PR fixes it.